### PR TITLE
Enable bash support from Docksal on container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM node:10-alpine
 
 WORKDIR /app
 
+# Add in bash so that Docksal can ssh into this container.
+RUN apk add --no-cache bash
+
 COPY package.json /app
 RUN npm install
 COPY . /app


### PR DESCRIPTION
When this container is used with [Docksal](https://docksal.io/), and presumably this would happen with raw `docker exec` commands as well, `bash` isn't available on the container to run commands against from the host system.

For example, running `fin bash MY_VUE_PA11Y_CONTAINER` returns:
> _OCI runtime exec failed: exec failed: container_linux.go:348: starting container process caused "exec: \"bash\": executable file not found in $PATH": unknown_

Since the Alpine container is so slim, I think just adding in bash support is warranted since this is a container we leave running with the `npm run dev` command.